### PR TITLE
Add Z3 builder class to Symbolic Executor

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -138,7 +138,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "dae03eebba55a2697a376e58b573a29fe36893157173ac8df312ad85f3c0e012"
 dependencies = [
  "askama_escape",
- "nom",
+ "nom 7.1.0",
  "proc-macro2",
  "quote",
  "serde",
@@ -162,6 +162,29 @@ name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
+name = "bindgen"
+version = "0.58.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f8523b410d7187a43085e7e064416ea32ded16bd0a4e6fc025e21616d01258f"
+dependencies = [
+ "bitflags",
+ "cexpr",
+ "clang-sys",
+ "clap 2.34.0",
+ "env_logger 0.8.4",
+ "lazy_static",
+ "lazycell",
+ "log",
+ "peeking_take_while",
+ "proc-macro2",
+ "quote",
+ "regex",
+ "rustc-hash",
+ "shlex",
+ "which",
+]
 
 [[package]]
 name = "bitflags"
@@ -502,6 +525,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "cexpr"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4aedb84272dbe89af497cf81375129abda4fc0a9e7c5d317498c15cc30c0d27"
+dependencies = [
+ "nom 5.1.2",
+]
+
+[[package]]
 name = "cfg-if"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -582,6 +614,17 @@ dependencies = [
  "num-traits",
  "time",
  "winapi",
+]
+
+[[package]]
+name = "clang-sys"
+version = "1.3.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5a050e2153c5be08febd6734e29298e844fdb0fa21aeddd63b4eb7baa106c69b"
+dependencies = [
+ "glob",
+ "libc",
+ "libloading",
 ]
 
 [[package]]
@@ -2442,6 +2485,16 @@ checksum = "e4a24736216ec316047a1fc4252e27dabb04218aa4a3f37c6e7ddbf1f9782b54"
 
 [[package]]
 name = "nom"
+version = "5.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ffb4262d26ed83a1c0a33a38fe2bb15797329c85770da05e6b828ddb782627af"
+dependencies = [
+ "memchr",
+ "version_check",
+]
+
+[[package]]
+name = "nom"
 version = "7.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1b1d11e1ef389c76fe5b81bcaf2ea32cf88b62bc494e19f493d0b30e7a930109"
@@ -2706,6 +2759,12 @@ name = "pathdiff"
 version = "0.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8835116a5c179084a830efb3adc117ab007512b535bc1a21c991d3b32a6b44dd"
+
+[[package]]
+name = "peeking_take_while"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19b17cddbe7ec3f8bc800887bab5e717348c95ea2ca0b1bf0837fb964dc67099"
 
 [[package]]
 name = "percent-encoding"
@@ -4405,6 +4464,7 @@ dependencies = [
  "rustc_traits",
  "smallvec",
  "tracing",
+ "z3",
 ]
 
 [[package]]
@@ -5796,6 +5856,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "which"
+version = "3.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d011071ae14a2f6671d0b74080ae0cd8ebf3a6f8c9589a2cd45f23126fe29724"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "winapi"
 version = "0.3.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5883,4 +5952,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fe5c30ade05e61656247b2e334a031dfd0cc466fadef865bdcdea8d537951bf1"
 dependencies = [
  "winapi",
+]
+
+[[package]]
+name = "z3"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d25754b4bf4516a65d0e596ea9c1f0082224bdf20823a37fdd9111fa08d5bf48"
+dependencies = [
+ "lazy_static",
+ "log",
+ "z3-sys",
+]
+
+[[package]]
+name = "z3-sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1c82dcbc58be4bf1994c520066cb2bd6c3d36aed0fdc57244f34d277421986a6"
+dependencies = [
+ "bindgen",
+ "cmake",
 ]

--- a/compiler/rustc_symbolic_exec/src/lib.rs
+++ b/compiler/rustc_symbolic_exec/src/lib.rs
@@ -34,6 +34,9 @@ use rustc_middle::mir::StatementKind;
 use rustc_middle::ty::query::Providers;
 use rustc_middle::ty::{self, TyCtxt};
 
+pub mod z3_builder;
+pub mod z3_example;
+
 const COMMON_END_NODE: &str = "common_end";
 
 pub fn provide(providers: &mut Providers) {

--- a/compiler/rustc_symbolic_exec/src/z3_builder.rs
+++ b/compiler/rustc_symbolic_exec/src/z3_builder.rs
@@ -1,4 +1,5 @@
 use z3::{ast::{Ast, self}, Solver, SatResult};
+use tracing::debug;
 
 pub struct Z3Builder<'a> {
     i_bool: i32,
@@ -21,6 +22,7 @@ impl Z3Builder<'_> {
         let x1 = ast::Bool::new_const(self.solver.get_context(), x1_name);
         let x2 = ast::Bool::new_const(self.solver.get_context(), x2_name);
 
+        // Dummy debug to use i_x struct fields
         debug!("solver: {:?} {:?} {:?}", self.i_bool, self.i_const, self.i_int);
 
         ast::Bool::and(&self.solver.get_context(), &[&x1, &x2])
@@ -88,7 +90,7 @@ impl Z3Builder<'_> {
 
         ast::Int::add(self.solver.get_context(), &[&x1, &x2])
     }
-    
+
     pub fn gen_const<'a>(&'a self, x1_name: &'a str, x2: i32) -> () {
         let x1 = ast::Int::new_const(self.solver.get_context(), x1_name);
         let unnamed_const = ast::Int::from_bv(&ast::BV::from_i64(self.solver.get_context(), x2.into(), 32), true);
@@ -109,14 +111,14 @@ impl Z3Builder<'_> {
     }
 
     pub fn check_bounds<'a>(&'a self, x1: &ast::Int<'a>) -> ast::Bool<'a> {
-        
+
         let min_int = ast::Int::from_bv(&ast::BV::from_i64(self.solver.get_context(), i32::MIN.into(), 32), true);
         let max_int = ast::Int::from_bv(&ast::BV::from_i64(self.solver.get_context(), i32::MAX.into(), 32), true);
 
         ast::Bool::and(self.solver.get_context(), &[&x1.le(&max_int), &x1.ge(&min_int)])
     }
 
-    
+
     pub fn create_const_int<'a>(&'a mut self, x: i32) -> String {
         let x1_name = format!("_const_{}", self.i_const);
         self.i_const += 1;
@@ -161,7 +163,7 @@ impl Z3Builder<'_> {
             None
         }
     }
-    
+
     pub fn check_solver<'a>(&'a self) -> SatResult {
         return self.solver.check();
     }

--- a/compiler/rustc_symbolic_exec/src/z3_builder.rs
+++ b/compiler/rustc_symbolic_exec/src/z3_builder.rs
@@ -1,0 +1,168 @@
+use z3::{ast::{Ast, self}, Solver, SatResult};
+
+pub struct Z3Builder<'a> {
+    i_bool: i32,
+    i_int: i32,
+    i_const: i32,
+    solver: &'a Solver<'a>
+}
+
+impl Z3Builder<'_> {
+    pub fn new<'a>(solver: &'a Solver<'a>) -> Z3Builder<'a> {
+        Z3Builder {
+            i_bool: 0,
+            i_int: 0,
+            i_const: 0,
+            solver
+        }
+    }
+
+    pub fn gen_land<'a>(&'a self, x1_name: &'a str, x2_name: &'a str) -> ast::Bool<'a> {
+        let x1 = ast::Bool::new_const(self.solver.get_context(), x1_name);
+        let x2 = ast::Bool::new_const(self.solver.get_context(), x2_name);
+
+        debug!("solver: {:?} {:?} {:?}", self.i_bool, self.i_const, self.i_int);
+
+        ast::Bool::and(&self.solver.get_context(), &[&x1, &x2])
+    }
+
+    pub fn gen_lor<'a>(&'a self, x1_name: &'a str, x2_name: &'a str) -> ast::Bool<'a> {
+        let x1 = ast::Bool::new_const(self.solver.get_context(), x1_name);
+        let x2 = ast::Bool::new_const(self.solver.get_context(), x2_name);
+
+        ast::Bool::or(&self.solver.get_context(), &[&x1, &x2])
+    }
+
+    pub fn gen_limplies<'a>(&'a self, x1_name: &'a str, x2_name: &'a str) -> ast::Bool<'a> {
+        let x1 = ast::Bool::new_const(self.solver.get_context(), x1_name);
+        let x2 = ast::Bool::new_const(self.solver.get_context(), x2_name);
+
+        x1.implies(&x2)
+    }
+
+    pub fn gen_liff<'a>(&'a self, x1_name: &'a str, x2_name: &'a str) -> ast::Bool<'a> {
+        let x1 = ast::Bool::new_const(self.solver.get_context(), x1_name);
+        let x2 = ast::Bool::new_const(self.solver.get_context(), x2_name);
+
+        x1.iff(&x2)
+    }
+
+    pub fn gen_lnot<'a>(&'a self, x1_name: &'a str) -> ast::Bool<'a> {
+        let x1 = ast::Bool::new_const(self.solver.get_context(), x1_name);
+
+        x1.not()
+    }
+
+    pub fn gen_gt<'a>(&'a self, x1_name: &'a str, x2_name: &'a str) -> ast::Bool<'a> {
+        let x1 = ast::Int::new_const(self.solver.get_context(), x1_name);
+        let x2 = ast::Int::new_const(self.solver.get_context(), x2_name);
+
+        x1.gt(&x2)
+    }
+
+    pub fn gen_eq<'a>(&'a self, x1_name: &'a str, x2_name: &'a str) -> ast::Bool<'a> {
+        let x1 = ast::Int::new_const(self.solver.get_context(), x1_name);
+        let x2 = ast::Int::new_const(self.solver.get_context(), x2_name);
+
+        x1._eq(&x2)
+    }
+
+    pub fn gen_ge<'a>(&'a self, x1_name: &'a str, x2_name: &'a str) -> ast::Bool<'a> {
+        let x1 = ast::Int::new_const(self.solver.get_context(), x1_name);
+        let x2 = ast::Int::new_const(self.solver.get_context(), x2_name);
+
+        x1.ge(&x2)
+    }
+
+
+    pub fn gen_mul<'a>(&'a self, x1_name: &'a str, x2_name: &'a str) -> ast::Int<'a> {
+        let x1 = ast::Int::new_const(self.solver.get_context(), x1_name);
+        let x2 = ast::Int::new_const(self.solver.get_context(), x2_name);
+
+        ast::Int::mul(self.solver.get_context(), &[&x1, &x2])
+    }
+
+    pub fn gen_add<'a>(&'a self, x1_name: &'a str, x2_name: &'a str) -> ast::Int<'a> {
+        let x1 = ast::Int::new_const(self.solver.get_context(), x1_name);
+        let x2 = ast::Int::new_const(self.solver.get_context(), x2_name);
+
+        ast::Int::add(self.solver.get_context(), &[&x1, &x2])
+    }
+    
+    pub fn gen_const<'a>(&'a self, x1_name: &'a str, x2: i32) -> () {
+        let x1 = ast::Int::new_const(self.solver.get_context(), x1_name);
+        let unnamed_const = ast::Int::from_bv(&ast::BV::from_i64(self.solver.get_context(), x2.into(), 32), true);
+
+        self.add_assertion(&x1._eq(&unnamed_const));
+    }
+
+    pub fn gen_int<'a>(&'a self, x1_name: &'a str, x1_bool: ast::Int<'a>) -> () {
+        let x1 = ast::Int::new_const(self.solver.get_context(), x1_name);
+
+        self.add_assertion(&x1._eq(&x1_bool));
+    }
+
+    pub fn gen_bool<'a>(&'a self, x1_name: &'a str, x1_bool: ast::Bool<'a>) -> () {
+        let x1 = ast::Bool::new_const(self.solver.get_context(), x1_name);
+
+        self.add_assertion(&x1._eq(&x1_bool));
+    }
+
+    pub fn check_bounds<'a>(&'a self, x1: &ast::Int<'a>) -> ast::Bool<'a> {
+        
+        let min_int = ast::Int::from_bv(&ast::BV::from_i64(self.solver.get_context(), i32::MIN.into(), 32), true);
+        let max_int = ast::Int::from_bv(&ast::BV::from_i64(self.solver.get_context(), i32::MAX.into(), 32), true);
+
+        ast::Bool::and(self.solver.get_context(), &[&x1.le(&max_int), &x1.ge(&min_int)])
+    }
+
+    
+    pub fn create_const_int<'a>(&'a mut self, x: i32) -> String {
+        let x1_name = format!("_const_{}", self.i_const);
+        self.i_const += 1;
+        let unnamed_const = ast::Int::from_bv(&ast::BV::from_i64(self.solver.get_context(), x.into(), 32), true);
+
+        let x1_const = ast::Int::new_const(&self.solver.get_context(), x1_name.clone());
+        self.add_assertion(&x1_const._eq(&unnamed_const));
+
+        x1_name
+    }
+
+    pub fn create_int<'a>(&'a mut self, x: &ast::Int<'a>) -> String {
+        let x1_name = format!("_int_{}", self.i_int);
+        self.i_int += 1;
+
+        let x1_int = ast::Int::new_const(&self.solver.get_context(), x1_name.clone());
+        self.add_assertion(&x1_int._eq(&x));
+
+        x1_name
+    }
+
+    pub fn create_bool<'a>(&'a mut self, x: &ast::Bool<'a>) -> String {
+        let x1_name = format!("_bool_{}", self.i_bool);
+        self.i_bool += 1;
+
+        let x1_bool = ast::Bool::new_const(&self.solver.get_context(), x1_name.clone());
+        self.add_assertion(&x1_bool._eq(x));
+
+        x1_name
+    }
+
+    pub fn add_assertion<'a>(&'a self, condition: &ast::Bool<'a>) -> () {
+        self.solver.assert(condition);
+    }
+
+    pub fn resolve_variable<'a>(&'a self, x_name: &'a str) -> Option<i64> {
+        let x = ast::Int::new_const(&self.solver.get_context(), x_name);
+        if self.check_solver() == SatResult::Sat {
+            let model = self.solver.get_model().unwrap();
+            Some(model.eval(&x, true).unwrap().as_i64().unwrap())
+        } else {
+            None
+        }
+    }
+    
+    pub fn check_solver<'a>(&'a self) -> SatResult {
+        return self.solver.check();
+    }
+}

--- a/compiler/rustc_symbolic_exec/src/z3_example.rs
+++ b/compiler/rustc_symbolic_exec/src/z3_example.rs
@@ -1,5 +1,6 @@
 use crate::z3_builder::Z3Builder;
 use z3::{Config, Context, Solver};
+use tracing::debug;
 
 
 pub fn example_z3() -> () {

--- a/compiler/rustc_symbolic_exec/src/z3_example.rs
+++ b/compiler/rustc_symbolic_exec/src/z3_example.rs
@@ -1,0 +1,26 @@
+use crate::z3_builder::Z3Builder;
+use z3::{Config, Context, Solver};
+
+
+pub fn example_z3() -> () {
+    // Initialize the Z3 and Builder objects
+    let cfg = Config::new();
+    let ctx = Context::new(&cfg);
+    let solver = Solver::new(&ctx);
+    let z3_builder = Z3Builder::new(&solver);
+
+    // Create three logical expressions we want to create a conjunction with
+    let xand1 = z3_builder.gen_eq("x1", "x2");
+    z3_builder.gen_const("x_const", 5);
+    let xand2 = z3_builder.gen_eq("x1", "x_const");
+    let xge1 = z3_builder.gen_ge("x1", "x2");
+
+    // Insert expressions into the builder
+    z3_builder.add_assertion(&xand1);
+    z3_builder.add_assertion(&xge1);
+    z3_builder.add_assertion(&xand2);
+
+    // Attempt resolving the model (and obtaining the respective values of x1, x2)
+    debug!("Resolved value: {:?}", z3_builder.check_solver());
+    debug!("x1: {:?}; x2: {:?}; x_const: {:?}", z3_builder.resolve_variable("x1"), z3_builder.resolve_variable("x2"), z3_builder.resolve_variable("x_const"));
+}


### PR DESCRIPTION
PR adds the `Z3Builder` struct to the symbolic executor providing basic blocks for building logical expressions. `example_z3` function provided for example code of using the `Z3Builder` struct.